### PR TITLE
fixed type coercion on ParameterGroup

### DIFF
--- a/ssm-cache-impl.go
+++ b/ssm-cache-impl.go
@@ -141,7 +141,7 @@ func (ssmCache *ssmCacheImpl) GetExpiringParameterGroup(groupKey string,
 		Recursive: aws.Bool(true),
 	}
 	// Walk the pages...
-	paramMap := make(map[string]interface{}, 0)
+	paramMap := ParameterGroup(make(map[string]interface{}, 0))
 	pagingErr := ssmCache.ssmSvc.GetParametersByPathPages(paramByPathInput,
 		func(page *ssm.GetParametersByPathOutput, lastPage bool) bool {
 			for _, eachParam := range page.Parameters {


### PR DESCRIPTION
Just added cast to `ParameterGroup` type alias when populating cache entry. Otherwise it always failing type check on cache hit.